### PR TITLE
Translations update from OSGeo Weblate

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -8,5 +8,8 @@ de:
           enabled: Aktiviert
           disabled: Deaktiviert
           enabled_no_email: Aktiviert, keine E-Mails
+        x_devices_registered:
+          one: Derzeit sind keine Geräte registriert.
+          other: Derzeit sind %{count} Geräte registriert.
   field_push_notifications: Push-Nachrichten
   label_expo_push_experience_id: Expo Experience ID


### PR DESCRIPTION
Translations update from [OSGeo Weblate](https://weblate.osgeo.org) for [GTT Project/Redmine Expo Push Notifications plugin](https://weblate.osgeo.org/projects/gtt-project/redmine_expo_push/).



Current translation status:

![Weblate translation status](https://weblate.osgeo.org/widget/gtt-project/redmine_expo_push/horizontal-auto.svg)