### PR TITLE
Use official exponent-server-sdk gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-gem 'exponent-server-sdk', git: 'https://github.com/gtt-project/expo-server-sdk-ruby.git', tag: 'v0.1.0-dev1'
+gem 'exponent-server-sdk'


### PR DESCRIPTION
Supports #6.

Changes proposed in this pull request:
- [x] Use official exponent-server-sdk gem
- [ ] ~~Check actual behavior on Expo example app (at least on iOS ExpoGo app)~~
  - ~~(In my memory, there was Thibault made simple app, so I will check it. Otherwise, I will create a simple app.)~~

@gtt-project/maintainer
